### PR TITLE
refactor(transformer): 使用 delete 替代赋值为 undefined 来清除过滤属性

### DIFF
--- a/src/transformer/Transformer.ts
+++ b/src/transformer/Transformer.ts
@@ -176,7 +176,7 @@ export class Transformer {
     const fieldList = Object.keys(this)
     for (const field of fieldList) {
       if (!fields.includes(field)) {
-        ;(this as IJson)[field] = undefined
+        delete (this as IJson)[field]
       }
     }
     return this
@@ -190,7 +190,7 @@ export class Transformer {
     const fieldList = Object.keys(this)
     for (const field of fieldList) {
       if (fields.includes(field)) {
-        ;(this as IJson)[field] = undefined
+        delete (this as IJson)[field]
       }
     }
     return this


### PR DESCRIPTION
可能需要考虑一下下面的问题：

此类操作直接会修改对象实例，可能需要新增 `exposeSafe` 、`excludeSafe` 内置 copy 指令，不影响实例对象。

或者添加相关文档说明、jsdoc，注明这两个方法的“不纯性”，引导在方法调用之前，copy 实例之后再进行过滤操作。